### PR TITLE
Remove users ability to select date in the past for booking

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -57,7 +57,7 @@
           <label for="date-search-field" class="hidden">Select a date</label>
           <input aria-label="Please enter a date current date selected is. " id="date-search-field" class="date-search-field" type="date" name="" value="">
           <label for="search-field" class="hidden">Select a date</label>
-          <select aria-label="Optional room type selection" id="search-field" class="search-field" name="reservation-filter" id="rooms">
+          <select aria-label="Optional room type selection" id="search-field" class="search-field" name="reservation-filter" id="rooms" min="Date.now()">
             <option value="select">Optional</option>
             <option value="residential suite">Residential Suite</option>
             <option value="suite">Suite</option>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -50,6 +50,9 @@ loginButton.addEventListener('click', (event) => {
 })
 
 makeNewReservatiolnButton.addEventListener('click', (event) => {
+  const test = JSON.stringify(getCurrentDate())
+  test.split(",")[0]
+  dateInput.min = test.slice(0, 4) + '-' + test.slice(4, 6) + '-' + test.slice(6, 8)
   showElement([dashboardPage, mainPage, reservationPage], reservationPage)
 })
 


### PR DESCRIPTION
# Description
Removes the ability for users to select dates to filter reservations before current date.

## Issues


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring

# How Has This Been Tested?
- [x] open localHost
- [x] dev tools

# Checklist:
- [x] My code follows the Turing's guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No console error messages
